### PR TITLE
Added the clear all filters button

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -13,6 +13,9 @@ return [
     // The addon will calculate the number of entries for each filter value (can be slow for a large number of entries)
     'enable_filter_values_count' => false,
 
+    // Enable the clear all filters button
+    'enable_clear_all_filters' => false,
+
     // Enable custom query string
     'custom_query_string' => false,
 

--- a/resources/lang/en/ui.php
+++ b/resources/lang/en/ui.php
@@ -2,6 +2,7 @@
 
 return [
     'clear_filters' => 'Clear filter',
+    'clear_all_filters' => 'Clear all filters',
     'default' => 'Default',
     'all' => 'All',
     'value' => 'Value',

--- a/resources/views/livewire/ui/clear-all-filters.blade.php
+++ b/resources/views/livewire/ui/clear-all-filters.blade.php
@@ -1,0 +1,14 @@
+<div>
+    @if(config('statamic-livewire-filters.enable_clear_all_filters') && $this->hasParams && !$this->cleared)
+        <button 
+            type="button" 
+            class="px-3 py-2 text-sm font-medium text-center flex items-center text-white bg-gray-800 hover:bg-gray-900 focus:outline-none focus:ring-4 focus:ring-gray-300"
+            wire:click="clearAll"
+        >
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-2">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
+            </svg>
+            {{ __('statamic-livewire-filters::ui.clear_all_filters') }}
+        </button>
+    @endif
+</div>

--- a/resources/views/livewire/ui/clear-all-filters.blade.php
+++ b/resources/views/livewire/ui/clear-all-filters.blade.php
@@ -1,8 +1,8 @@
 <div>
-    @if(config('statamic-livewire-filters.enable_clear_all_filters') && $this->hasParams && !$this->cleared)
+    @if($this->showClearButton)
         <button 
             type="button" 
-            class="px-3 py-2 text-sm font-medium text-center flex items-center text-white bg-gray-800 hover:bg-gray-900 focus:outline-none focus:ring-4 focus:ring-gray-300"
+            class="px-3 py-2 text-sm font-medium text-center flex items-center text-white bg-gray-800 hover:bg-gray-900 focus:outline-none focus:ring-4 focus:ring-gray-300 {{ $class }}"
             wire:click="clearAll"
         >
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 mr-2">

--- a/src/Http/Livewire/LfCheckboxFilter.php
+++ b/src/Http/Livewire/LfCheckboxFilter.php
@@ -31,7 +31,8 @@ class LfCheckboxFilter extends Component
             $this->validate();
         }
 
-        $this->dispatch('filter-updated',
+        $this->dispatch(
+            'filter-updated',
             field: $this->field,
             condition: $this->condition,
             payload: $this->selected,
@@ -40,6 +41,7 @@ class LfCheckboxFilter extends Component
             ->to(LivewireCollection::class);
     }
 
+    #[On('clear-all-filters')]
     public function clear()
     {
         $this->selected = [];
@@ -74,6 +76,6 @@ class LfCheckboxFilter extends Component
 
     public function render()
     {
-        return view('statamic-livewire-filters::livewire.filters.'.$this->view);
+        return view('statamic-livewire-filters::livewire.filters.' . $this->view);
     }
 }

--- a/src/Http/Livewire/LfCheckboxFilter.php
+++ b/src/Http/Livewire/LfCheckboxFilter.php
@@ -76,6 +76,6 @@ class LfCheckboxFilter extends Component
 
     public function render()
     {
-        return view('statamic-livewire-filters::livewire.filters.' . $this->view);
+        return view('statamic-livewire-filters::livewire.filters.'.$this->view);
     }
 }

--- a/src/Http/Livewire/LfClearAllFilters.php
+++ b/src/Http/Livewire/LfClearAllFilters.php
@@ -10,14 +10,19 @@ class LfClearAllFilters extends Component
 {
     public $view = 'clear-all-filters';
 
+    public $class;
+
     public $params;
 
     public $cleared = false;
 
     #[Computed]
-    public function hasParams()
+    public function showClearButton()
     {
-        return $this->params && collect($this->params)->except(['sort'])->isNotEmpty();
+        return config('statamic-livewire-filters.enable_clear_all_filters')
+            && $this->params
+            && collect($this->params)->except(['sort'])->isNotEmpty()
+            && !$this->cleared;
     }
 
     #[On('clear-all-params-updated')]

--- a/src/Http/Livewire/LfClearAllFilters.php
+++ b/src/Http/Livewire/LfClearAllFilters.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Reach\StatamicLivewireFilters\Http\Livewire;
+
+use Livewire\Attributes\Computed;
+use Livewire\Attributes\On;
+use Livewire\Component;
+
+class LfClearAllFilters extends Component
+{
+    public $view = 'clear-all-filters';
+
+    public $params;
+
+    public $cleared = false;
+
+    #[Computed]
+    public function hasParams()
+    {
+        return $this->params && collect($this->params)->except(['sort'])->isNotEmpty();
+    }
+
+    #[On('clear-all-params-updated')]
+    public function updateParams($params)
+    {
+        $this->params = $params;
+        $this->cleared = false;
+    }
+
+    public function clearAll()
+    {
+        $this->cleared = true;
+        $this->dispatch('clear-all-filters');
+    }
+
+    public function render()
+    {
+        return view('statamic-livewire-filters::livewire.ui.' . $this->view);
+    }
+}

--- a/src/Http/Livewire/LfClearAllFilters.php
+++ b/src/Http/Livewire/LfClearAllFilters.php
@@ -22,7 +22,7 @@ class LfClearAllFilters extends Component
         return config('statamic-livewire-filters.enable_clear_all_filters')
             && $this->params
             && collect($this->params)->except(['sort'])->isNotEmpty()
-            && !$this->cleared;
+            && ! $this->cleared;
     }
 
     #[On('clear-all-params-updated')]
@@ -40,6 +40,6 @@ class LfClearAllFilters extends Component
 
     public function render()
     {
-        return view('statamic-livewire-filters::livewire.ui.' . $this->view);
+        return view('statamic-livewire-filters::livewire.ui.'.$this->view);
     }
 }

--- a/src/Http/Livewire/LfDualRangeFilter.php
+++ b/src/Http/Livewire/LfDualRangeFilter.php
@@ -54,7 +54,8 @@ class LfDualRangeFilter extends Component
             $this->modifier = 'is_after|is_before';
         }
 
-        $this->dispatch('filter-updated',
+        $this->dispatch(
+            'filter-updated',
             field: $this->field,
             condition: $this->condition,
             payload: [
@@ -86,6 +87,14 @@ class LfDualRangeFilter extends Component
         $this->dispatchEvent();
     }
 
+    #[On('clear-all-filters')]
+    public function clear()
+    {
+        $this->selectedMin = $this->min;
+        $this->selectedMax = $this->max;
+        $this->clearFilters();
+    }
+
     #[On('preset-params')]
     public function setPresetValues($params)
     {
@@ -96,7 +105,8 @@ class LfDualRangeFilter extends Component
         if (isset($params[$paramKeys['max']])) {
             $this->selectedMax = $params[$paramKeys['max']];
         }
-        $this->dispatch('dual-range-preset-values',
+        $this->dispatch(
+            'dual-range-preset-values',
             min: $this->selectedMin,
             max: $this->selectedMax,
         );
@@ -104,6 +114,6 @@ class LfDualRangeFilter extends Component
 
     public function render()
     {
-        return view('statamic-livewire-filters::livewire.filters.'.$this->view);
+        return view('statamic-livewire-filters::livewire.filters.' . $this->view);
     }
 }

--- a/src/Http/Livewire/LfDualRangeFilter.php
+++ b/src/Http/Livewire/LfDualRangeFilter.php
@@ -114,6 +114,6 @@ class LfDualRangeFilter extends Component
 
     public function render()
     {
-        return view('statamic-livewire-filters::livewire.filters.' . $this->view);
+        return view('statamic-livewire-filters::livewire.filters.'.$this->view);
     }
 }

--- a/src/Http/Livewire/Traits/HandleParams.php
+++ b/src/Http/Livewire/Traits/HandleParams.php
@@ -71,7 +71,7 @@ trait HandleParams
 
     protected function handleCondition($field, $condition, $payload)
     {
-        $paramKey = $field.':'.$condition;
+        $paramKey = $field . ':' . $condition;
         $this->params[$paramKey] = $this->toPipeSeparatedString($payload);
 
         $this->dispatchParamsUpdated();
@@ -79,7 +79,7 @@ trait HandleParams
 
     protected function handleTaxonomyCondition($field, $payload, $modifier)
     {
-        $paramKey = 'taxonomy:'.$field.':'.$modifier;
+        $paramKey = 'taxonomy:' . $field . ':' . $modifier;
         $this->params[$paramKey] = $this->toPipeSeparatedString($payload);
 
         $this->dispatchParamsUpdated();
@@ -89,7 +89,7 @@ trait HandleParams
     protected function handleQueryScopeCondition($field, $payload, $modifier)
     {
         $queryScopeKey = 'query_scope';
-        $modifierKey = $modifier.':'.$field;
+        $modifierKey = $modifier . ':' . $field;
 
         if (isset($this->params[$queryScopeKey])) {
             $existingScopes = collect(explode('|', $this->params[$queryScopeKey]));
@@ -110,8 +110,8 @@ trait HandleParams
     {
         [$minModifier, $maxModifier] = $this->getDualRangeConditions($modifier);
 
-        $minParamKey = $field.':'.$minModifier;
-        $maxParamKey = $field.':'.$maxModifier;
+        $minParamKey = $field . ':' . $minModifier;
+        $maxParamKey = $field . ':' . $maxModifier;
 
         $this->params[$minParamKey] = $payload['min'];
         $this->params[$maxParamKey] = $payload['max'];
@@ -126,12 +126,12 @@ trait HandleParams
             $queryScopeKey = 'query_scope';
 
             // First unset the field's data
-            $modifierKey = $modifier.':'.$field;
+            $modifierKey = $modifier . ':' . $field;
             unset($this->params[$modifierKey]);
 
             $existingScopes = collect(explode('|', $this->params[$queryScopeKey]));
             $existingParams = collect($this->params)->filter(function ($value, $key) use ($modifier) {
-                return Str::startsWith($key, $modifier.':');
+                return Str::startsWith($key, $modifier . ':');
             });
 
             // If there no more fields using this scope, let's remove it
@@ -154,7 +154,7 @@ trait HandleParams
             return;
         }
         if ($condition === 'taxonomy') {
-            $paramKey = 'taxonomy:'.$field.':'.$modifier;
+            $paramKey = 'taxonomy:' . $field . ':' . $modifier;
             unset($this->params[$paramKey]);
             $this->dispatchParamsUpdated();
 
@@ -163,15 +163,15 @@ trait HandleParams
         if ($condition === 'dual_range') {
             [$minModifier, $maxModifier] = $this->getDualRangeConditions($modifier);
 
-            $minParamKey = $field.':'.$minModifier;
-            $maxParamKey = $field.':'.$maxModifier;
+            $minParamKey = $field . ':' . $minModifier;
+            $maxParamKey = $field . ':' . $maxModifier;
 
             unset($this->params[$minParamKey], $this->params[$maxParamKey]);
             $this->dispatchParamsUpdated();
 
             return;
         }
-        unset($this->params[$field.':'.$condition]);
+        unset($this->params[$field . ':' . $condition]);
         $this->dispatchParamsUpdated();
     }
 
@@ -215,7 +215,7 @@ trait HandleParams
 
         // Only include params that have aliases configured
         $segments = collect($this->params)
-            ->filter(fn ($value, $key) => isset($aliases[$key]))
+            ->filter(fn($value, $key) => isset($aliases[$key]))
             ->map(function ($value, $key) use ($aliases) {
                 $urlKey = $aliases[$key];
 
@@ -231,10 +231,10 @@ trait HandleParams
 
         $path = $segments->isEmpty()
             ? ''
-            : $prefix.'/'.$segments->implode('/');
+            : $prefix . '/' . $segments->implode('/');
 
         $fullPath = $path
-            ? trim($this->currentPath, '/').'/'.trim($path, '/')
+            ? trim($this->currentPath, '/') . '/' . trim($path, '/')
             : $this->currentPath;
 
         $this->dispatch('update-url', newUrl: url($fullPath));
@@ -270,6 +270,10 @@ trait HandleParams
     {
         if (config('statamic-livewire-filters.enable_filter_values_count')) {
             $this->dispatch('params-updated', $this->params);
+        }
+
+        if (config('statamic-livewire-filters.enable_clear_all_filters')) {
+            $this->dispatch('clear-all-params-updated', $this->params);
         }
 
         // Dispatching to the tags component

--- a/src/Http/Livewire/Traits/HandleParams.php
+++ b/src/Http/Livewire/Traits/HandleParams.php
@@ -71,7 +71,7 @@ trait HandleParams
 
     protected function handleCondition($field, $condition, $payload)
     {
-        $paramKey = $field . ':' . $condition;
+        $paramKey = $field.':'.$condition;
         $this->params[$paramKey] = $this->toPipeSeparatedString($payload);
 
         $this->dispatchParamsUpdated();
@@ -79,7 +79,7 @@ trait HandleParams
 
     protected function handleTaxonomyCondition($field, $payload, $modifier)
     {
-        $paramKey = 'taxonomy:' . $field . ':' . $modifier;
+        $paramKey = 'taxonomy:'.$field.':'.$modifier;
         $this->params[$paramKey] = $this->toPipeSeparatedString($payload);
 
         $this->dispatchParamsUpdated();
@@ -89,7 +89,7 @@ trait HandleParams
     protected function handleQueryScopeCondition($field, $payload, $modifier)
     {
         $queryScopeKey = 'query_scope';
-        $modifierKey = $modifier . ':' . $field;
+        $modifierKey = $modifier.':'.$field;
 
         if (isset($this->params[$queryScopeKey])) {
             $existingScopes = collect(explode('|', $this->params[$queryScopeKey]));
@@ -110,8 +110,8 @@ trait HandleParams
     {
         [$minModifier, $maxModifier] = $this->getDualRangeConditions($modifier);
 
-        $minParamKey = $field . ':' . $minModifier;
-        $maxParamKey = $field . ':' . $maxModifier;
+        $minParamKey = $field.':'.$minModifier;
+        $maxParamKey = $field.':'.$maxModifier;
 
         $this->params[$minParamKey] = $payload['min'];
         $this->params[$maxParamKey] = $payload['max'];
@@ -126,12 +126,12 @@ trait HandleParams
             $queryScopeKey = 'query_scope';
 
             // First unset the field's data
-            $modifierKey = $modifier . ':' . $field;
+            $modifierKey = $modifier.':'.$field;
             unset($this->params[$modifierKey]);
 
             $existingScopes = collect(explode('|', $this->params[$queryScopeKey]));
             $existingParams = collect($this->params)->filter(function ($value, $key) use ($modifier) {
-                return Str::startsWith($key, $modifier . ':');
+                return Str::startsWith($key, $modifier.':');
             });
 
             // If there no more fields using this scope, let's remove it
@@ -154,7 +154,7 @@ trait HandleParams
             return;
         }
         if ($condition === 'taxonomy') {
-            $paramKey = 'taxonomy:' . $field . ':' . $modifier;
+            $paramKey = 'taxonomy:'.$field.':'.$modifier;
             unset($this->params[$paramKey]);
             $this->dispatchParamsUpdated();
 
@@ -163,15 +163,15 @@ trait HandleParams
         if ($condition === 'dual_range') {
             [$minModifier, $maxModifier] = $this->getDualRangeConditions($modifier);
 
-            $minParamKey = $field . ':' . $minModifier;
-            $maxParamKey = $field . ':' . $maxModifier;
+            $minParamKey = $field.':'.$minModifier;
+            $maxParamKey = $field.':'.$maxModifier;
 
             unset($this->params[$minParamKey], $this->params[$maxParamKey]);
             $this->dispatchParamsUpdated();
 
             return;
         }
-        unset($this->params[$field . ':' . $condition]);
+        unset($this->params[$field.':'.$condition]);
         $this->dispatchParamsUpdated();
     }
 
@@ -215,7 +215,7 @@ trait HandleParams
 
         // Only include params that have aliases configured
         $segments = collect($this->params)
-            ->filter(fn($value, $key) => isset($aliases[$key]))
+            ->filter(fn ($value, $key) => isset($aliases[$key]))
             ->map(function ($value, $key) use ($aliases) {
                 $urlKey = $aliases[$key];
 
@@ -231,10 +231,10 @@ trait HandleParams
 
         $path = $segments->isEmpty()
             ? ''
-            : $prefix . '/' . $segments->implode('/');
+            : $prefix.'/'.$segments->implode('/');
 
         $fullPath = $path
-            ? trim($this->currentPath, '/') . '/' . trim($path, '/')
+            ? trim($this->currentPath, '/').'/'.trim($path, '/')
             : $this->currentPath;
 
         $this->dispatch('update-url', newUrl: url($fullPath));

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -40,7 +40,7 @@ class ServiceProvider extends AddonServiceProvider
     ];
 
     protected $publishables = [
-        __DIR__ . '/../resources/build' => 'build',
+        __DIR__.'/../resources/build' => 'build',
     ];
 
     public function bootAddon()
@@ -58,18 +58,18 @@ class ServiceProvider extends AddonServiceProvider
         Livewire::component('lf-url-handler', LfUrlHandler::class);
         Livewire::component('lf-clear-all-filters', LfClearAllFilters::class);
 
-        $this->loadTranslationsFrom(__DIR__ . '/../resources/lang', 'statamic-livewire-filters');
+        $this->loadTranslationsFrom(__DIR__.'/../resources/lang', 'statamic-livewire-filters');
 
-        $this->loadViewsFrom(__DIR__ . '/../resources/views', 'statamic-livewire-filters');
+        $this->loadViewsFrom(__DIR__.'/../resources/views', 'statamic-livewire-filters');
 
-        $this->mergeConfigFrom(__DIR__ . '/../config/config.php', 'statamic-livewire-filters');
+        $this->mergeConfigFrom(__DIR__.'/../config/config.php', 'statamic-livewire-filters');
 
         $this->publishes([
-            __DIR__ . '/../resources/views' => resource_path('views/vendor/statamic-livewire-filters'),
+            __DIR__.'/../resources/views' => resource_path('views/vendor/statamic-livewire-filters'),
         ], 'statamic-livewire-filters-views');
 
         $this->publishes([
-            __DIR__ . '/../config/config.php' => config_path('statamic-livewire-filters.php'),
+            __DIR__.'/../config/config.php' => config_path('statamic-livewire-filters.php'),
         ], 'statamic-livewire-filters-config');
 
         if ($this->app->runningInConsole()) {

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -5,6 +5,7 @@ namespace Reach\StatamicLivewireFilters;
 use Illuminate\Support\Facades\Artisan;
 use Livewire\Livewire;
 use Reach\StatamicLivewireFilters\Http\Livewire\LfCheckboxFilter;
+use Reach\StatamicLivewireFilters\Http\Livewire\LfClearAllFilters;
 use Reach\StatamicLivewireFilters\Http\Livewire\LfDateFilter;
 use Reach\StatamicLivewireFilters\Http\Livewire\LfDualRangeFilter;
 use Reach\StatamicLivewireFilters\Http\Livewire\LfRadioFilter;
@@ -39,7 +40,7 @@ class ServiceProvider extends AddonServiceProvider
     ];
 
     protected $publishables = [
-        __DIR__.'/../resources/build' => 'build',
+        __DIR__ . '/../resources/build' => 'build',
     ];
 
     public function bootAddon()
@@ -55,19 +56,20 @@ class ServiceProvider extends AddonServiceProvider
         Livewire::component('lf-sort', LfSort::class);
         Livewire::component('lf-tags', LfTags::class);
         Livewire::component('lf-url-handler', LfUrlHandler::class);
+        Livewire::component('lf-clear-all-filters', LfClearAllFilters::class);
 
-        $this->loadTranslationsFrom(__DIR__.'/../resources/lang', 'statamic-livewire-filters');
+        $this->loadTranslationsFrom(__DIR__ . '/../resources/lang', 'statamic-livewire-filters');
 
-        $this->loadViewsFrom(__DIR__.'/../resources/views', 'statamic-livewire-filters');
+        $this->loadViewsFrom(__DIR__ . '/../resources/views', 'statamic-livewire-filters');
 
-        $this->mergeConfigFrom(__DIR__.'/../config/config.php', 'statamic-livewire-filters');
+        $this->mergeConfigFrom(__DIR__ . '/../config/config.php', 'statamic-livewire-filters');
 
         $this->publishes([
-            __DIR__.'/../resources/views' => resource_path('views/vendor/statamic-livewire-filters'),
+            __DIR__ . '/../resources/views' => resource_path('views/vendor/statamic-livewire-filters'),
         ], 'statamic-livewire-filters-views');
 
         $this->publishes([
-            __DIR__.'/../config/config.php' => config_path('statamic-livewire-filters.php'),
+            __DIR__ . '/../config/config.php' => config_path('statamic-livewire-filters.php'),
         ], 'statamic-livewire-filters-config');
 
         if ($this->app->runningInConsole()) {


### PR DESCRIPTION
I was missing the ability to clear all filters at once in my project, so I decided to implement this functionality and submit it as a PR. I'd love to hear if this is something you're interested in adding to the package. If the approach and code look good to you, I'm happy to refactor anything needed and add proper documentation.

## Overview
This PR adds a new "Clear All Filters" button functionality to the Statamic Livewire Filters package. This feature allows users to clear all active filters at once, improving the user experience when working with multiple filters.

## Changes
- Added new config option `enable_clear_all_filters` (disabled by default)
- Created new Livewire component `LfClearAllFilters` for handling the clear all functionality
- Added translation support for the clear all button text
- Implemented reactive state handling to show/hide button based on active filters
- Added UI component with a styled button including an X icon

## Implementation Details
- Added clear all filters button in a new blade view component
- Button only shows when filters are active and clearing hasn't been triggered
- Uses Livewire events to communicate between components
- Maintains existing sorting functionality when clearing filters
- Follows existing code style and patterns

## Configuration
Users can enable the feature by setting `enable_clear_all_filters` to `true` in the config:
```php
// config/statamic-livewire-filters.php
'enable_clear_all_filters' => true,