### PR TITLE
 Add Entry Total Count Component

### DIFF
--- a/resources/lang/en/ui.php
+++ b/resources/lang/en/ui.php
@@ -3,6 +3,7 @@
 return [
     'clear_filters' => 'Clear filter',
     'default' => 'Default',
+    'entries' => '{0} entries|{1} entry|[2,*] entries',
     'all' => 'All',
     'value' => 'Value',
     'to' => 'to',

--- a/resources/views/livewire/ui/count.blade.php
+++ b/resources/views/livewire/ui/count.blade.php
@@ -1,0 +1,3 @@
+<span>
+    {{ $count }} {{ trans_choice('statamic-livewire-filters::ui.entries', $count) }}
+</span>

--- a/src/Http/Livewire/LfCount.php
+++ b/src/Http/Livewire/LfCount.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Reach\StatamicLivewireFilters\Http\Livewire;
+
+use Livewire\Attributes\On;
+use Livewire\Component;
+
+class LfCount extends Component
+{
+    public $count;
+
+    public $view = 'count';
+
+    #[On('total-count-updated')]
+    public function updatedCount($count)
+    {
+        $this->count = $count;
+    }
+
+    public function render()
+    {
+        return view('statamic-livewire-filters::livewire.ui.' . $this->view);
+    }
+}

--- a/src/Http/Livewire/LfCount.php
+++ b/src/Http/Livewire/LfCount.php
@@ -19,6 +19,6 @@ class LfCount extends Component
 
     public function render()
     {
-        return view('statamic-livewire-filters::livewire.ui.' . $this->view);
+        return view('statamic-livewire-filters::livewire.ui.'.$this->view);
     }
 }

--- a/src/Http/Livewire/LfCount.php
+++ b/src/Http/Livewire/LfCount.php
@@ -11,7 +11,7 @@ class LfCount extends Component
 
     public $view = 'count';
 
-    #[On('total-count-updated')]
+    #[On('entries-updated')]
     public function updatedCount($count)
     {
         $this->count = $count;

--- a/src/Http/Livewire/LivewireCollection.php
+++ b/src/Http/Livewire/LivewireCollection.php
@@ -78,7 +78,6 @@ class LivewireCollection extends Component
             return;
         }
         $this->params['sort'] = $sort;
-
     }
 
     protected function queryString()
@@ -113,6 +112,11 @@ class LivewireCollection extends Component
         // Update the URL if using custom query string
         $this->updateCustomQueryStringUrl();
 
+        // Get total count before pagination to pass to the count component
+        $totalCount = $entries->total();
+
+        $this->dispatch('total-count-updated', count: $totalCount);
+
         if ($this->paginate) {
             return $this->withPagination('entries', $entries);
         }
@@ -122,7 +126,7 @@ class LivewireCollection extends Component
 
     public function render()
     {
-        return view('statamic-livewire-filters::livewire.'.$this->view)->with([
+        return view('statamic-livewire-filters::livewire.' . $this->view)->with([
             ...$this->entries(),
         ]);
     }

--- a/src/Http/Livewire/LivewireCollection.php
+++ b/src/Http/Livewire/LivewireCollection.php
@@ -2,7 +2,6 @@
 
 namespace Reach\StatamicLivewireFilters\Http\Livewire;
 
-use Illuminate\Pagination\LengthAwarePaginator;
 use Livewire\Attributes\Locked;
 use Livewire\Attributes\On;
 use Livewire\Component;
@@ -129,10 +128,10 @@ class LivewireCollection extends Component
         $entries = $this->entries();
 
         // Get the total count of the entries depending on the type of the collection
-        if ($entries instanceof EntryCollection) {
-            $this->entriesCount = $entries->count();
-        } elseif ($entries instanceof LengthAwarePaginator) {
-            $this->entriesCount = $entries->total();
+        if (is_array($entries) && isset($entries['pagination_total'])) {
+            $this->entriesCount = $entries['pagination_total'];
+        } else {
+            $this->entriesCount = $entries['entries'] instanceof EntryCollection ? $entries['entries']->count() : null;
         }
 
         return view('statamic-livewire-filters::livewire.'.$this->view)->with([

--- a/src/Http/Livewire/LivewireCollection.php
+++ b/src/Http/Livewire/LivewireCollection.php
@@ -126,7 +126,7 @@ class LivewireCollection extends Component
 
     public function render()
     {
-        return view('statamic-livewire-filters::livewire.' . $this->view)->with([
+        return view('statamic-livewire-filters::livewire.'.$this->view)->with([
             ...$this->entries(),
         ]);
     }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -72,6 +72,10 @@ class ServiceProvider extends AddonServiceProvider
             __DIR__.'/../config/config.php' => config_path('statamic-livewire-filters.php'),
         ], 'statamic-livewire-filters-config');
 
+        $this->publishes([
+            __DIR__.'/../resources/lang' => resource_path('lang/vendor/statamic-livewire-filters'),
+        ], 'statamic-livewire-filters-lang');
+
         if ($this->app->runningInConsole()) {
             Artisan::call('statamic-livewire-filters:update');
         }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -40,7 +40,7 @@ class ServiceProvider extends AddonServiceProvider
     ];
 
     protected $publishables = [
-        __DIR__ . '/../resources/build' => 'build',
+        __DIR__.'/../resources/build' => 'build',
     ];
 
     public function bootAddon()
@@ -58,18 +58,18 @@ class ServiceProvider extends AddonServiceProvider
         Livewire::component('lf-url-handler', LfUrlHandler::class);
         Livewire::component('lf-count', LfCount::class);
 
-        $this->loadTranslationsFrom(__DIR__ . '/../resources/lang', 'statamic-livewire-filters');
+        $this->loadTranslationsFrom(__DIR__.'/../resources/lang', 'statamic-livewire-filters');
 
-        $this->loadViewsFrom(__DIR__ . '/../resources/views', 'statamic-livewire-filters');
+        $this->loadViewsFrom(__DIR__.'/../resources/views', 'statamic-livewire-filters');
 
-        $this->mergeConfigFrom(__DIR__ . '/../config/config.php', 'statamic-livewire-filters');
+        $this->mergeConfigFrom(__DIR__.'/../config/config.php', 'statamic-livewire-filters');
 
         $this->publishes([
-            __DIR__ . '/../resources/views' => resource_path('views/vendor/statamic-livewire-filters'),
+            __DIR__.'/../resources/views' => resource_path('views/vendor/statamic-livewire-filters'),
         ], 'statamic-livewire-filters-views');
 
         $this->publishes([
-            __DIR__ . '/../config/config.php' => config_path('statamic-livewire-filters.php'),
+            __DIR__.'/../config/config.php' => config_path('statamic-livewire-filters.php'),
         ], 'statamic-livewire-filters-config');
 
         if ($this->app->runningInConsole()) {

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -5,6 +5,7 @@ namespace Reach\StatamicLivewireFilters;
 use Illuminate\Support\Facades\Artisan;
 use Livewire\Livewire;
 use Reach\StatamicLivewireFilters\Http\Livewire\LfCheckboxFilter;
+use Reach\StatamicLivewireFilters\Http\Livewire\LfCount;
 use Reach\StatamicLivewireFilters\Http\Livewire\LfDateFilter;
 use Reach\StatamicLivewireFilters\Http\Livewire\LfDualRangeFilter;
 use Reach\StatamicLivewireFilters\Http\Livewire\LfRadioFilter;
@@ -39,7 +40,7 @@ class ServiceProvider extends AddonServiceProvider
     ];
 
     protected $publishables = [
-        __DIR__.'/../resources/build' => 'build',
+        __DIR__ . '/../resources/build' => 'build',
     ];
 
     public function bootAddon()
@@ -55,19 +56,20 @@ class ServiceProvider extends AddonServiceProvider
         Livewire::component('lf-sort', LfSort::class);
         Livewire::component('lf-tags', LfTags::class);
         Livewire::component('lf-url-handler', LfUrlHandler::class);
+        Livewire::component('lf-count', LfCount::class);
 
-        $this->loadTranslationsFrom(__DIR__.'/../resources/lang', 'statamic-livewire-filters');
+        $this->loadTranslationsFrom(__DIR__ . '/../resources/lang', 'statamic-livewire-filters');
 
-        $this->loadViewsFrom(__DIR__.'/../resources/views', 'statamic-livewire-filters');
+        $this->loadViewsFrom(__DIR__ . '/../resources/views', 'statamic-livewire-filters');
 
-        $this->mergeConfigFrom(__DIR__.'/../config/config.php', 'statamic-livewire-filters');
+        $this->mergeConfigFrom(__DIR__ . '/../config/config.php', 'statamic-livewire-filters');
 
         $this->publishes([
-            __DIR__.'/../resources/views' => resource_path('views/vendor/statamic-livewire-filters'),
+            __DIR__ . '/../resources/views' => resource_path('views/vendor/statamic-livewire-filters'),
         ], 'statamic-livewire-filters-views');
 
         $this->publishes([
-            __DIR__.'/../config/config.php' => config_path('statamic-livewire-filters.php'),
+            __DIR__ . '/../config/config.php' => config_path('statamic-livewire-filters.php'),
         ], 'statamic-livewire-filters-config');
 
         if ($this->app->runningInConsole()) {

--- a/tests/Feature/LfCountTest.php
+++ b/tests/Feature/LfCountTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Tests\Feature;
+
+use Facades\Reach\StatamicLivewireFilters\Tests\Factories\EntryFactory;
+use Livewire\Livewire;
+use Reach\StatamicLivewireFilters\Http\Livewire\LfCount;
+use Reach\StatamicLivewireFilters\Tests\PreventSavingStacheItemsToDisk;
+use Reach\StatamicLivewireFilters\Tests\TestCase;
+use Statamic\Facades;
+
+class LfCountTest extends TestCase
+{
+    use PreventSavingStacheItemsToDisk;
+
+    protected $collection;
+
+    protected $blueprint;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->collection = Facades\Collection::make('pages')->save();
+        $this->blueprint = Facades\Blueprint::make()->setContents([
+            'sections' => [
+                'main' => [
+                    'fields' => [
+                        [
+                            'handle' => 'title',
+                            'field' => [
+                                'type' => 'text',
+                                'display' => 'Title',
+                            ],
+                        ],
+                        [
+
+                            'handle' => 'item_options',
+                            'field' => [
+                                'type' => 'checkboxes',
+                                'display' => 'Checkbox',
+                                'listable' => 'hidden',
+                                'options' => [
+                                    'option1' => 'Option 1',
+                                    'option2' => 'Option 2',
+                                    'option3' => 'Option 3',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+        $this->blueprint->setHandle('pages')->setNamespace('collections.'.$this->collection->handle())->save();
+
+        $this->makeEntry($this->collection, 'a')->set('title', 'I Love Guitars')->set('item_options', 'option1')->save();
+        $this->makeEntry($this->collection, 'b')->set('title', 'I Love Drums')->set('item_options', 'option1')->save();
+        $this->makeEntry($this->collection, 'c')->set('title', 'I Hate Flutes')->set('item_options', 'option2')->save();
+
+    }
+
+    public function test_it_renders_the_component_and_shows_the_text()
+    {
+        Livewire::test(LfCount::class)
+            ->assertSee('entry');
+    }
+
+    public function test_it_listens_to_the_entries_updated_event()
+    {
+        Livewire::test(LfCount::class)
+            ->dispatch('entries-updated', 3)
+            ->assertSet('count', 3)
+            ->assertSee('3 entries');
+
+        Livewire::test(LfCount::class)
+            ->dispatch('entries-updated', 1)
+            ->assertSet('count', 1)
+            ->assertSee('1 entry');
+    }
+
+    protected function makeEntry($collection, $slug)
+    {
+        return EntryFactory::id($slug)->collection($collection)->slug($slug)->make();
+    }
+}


### PR DESCRIPTION
This PR adds a new entry count component to display the total number of entries matching the current filters in the Statamic Livewire Filters package. This feature improves user experience by providing immediate feedback about how many entries match their filter criteria. 

I'd love to hear if this is something you're interested in adding to the package. If the approach and code look good to you, I'm happy to refactor anything needed and add proper documentation.

## Overview

The component displays the total number of entries with proper pluralization support through Laravel's translation system. It updates reactively whenever filters are changed or search terms are modified.

## Changes

* Added new Livewire component `LfCount` for displaying entry counts
* Created blade view component for rendering the count display
* Added translation support for proper entry pluralization
* Implemented event-based updates to maintain count accuracy
* Added count dispatch in the main collection component

## Implementation Details

### New Components

1. `LfCount.php` Livewire Component:
   * Handles receiving count updates via Livewire events
   * Supports customizable view rendering
   * Uses translation system for proper pluralization

2. `count.blade.php` View:
   * Simple span-wrapped count display
   * Uses Laravel's trans_choice for proper pluralization
   * Minimal markup for easy styling customization

### Translations

Added new translation key in `resources/lang/en/ui.php`:
```php
'entries' => '{0} entries|{1} entry|[2,*] entries'
```

### Event System

The count is updated through Livewire's event system:
* Main collection component dispatches 'total-count-updated' event
* Count component listens for updates using Livewire's #[On] attribute
* Updates happen automatically when filters change

## Usage

Add the count component to your template:

```php
<livewire:lf-count />
```

The component will automatically receive updates whenever the entry count changes due to filtering or search operations.

## Example Output

Examples of how the component displays different counts:
- "0 entries"
- "1 entry"
- "42 entries"