### PR TITLE
Add multi-site support to filter options

### DIFF
--- a/src/Http/Livewire/Traits/HandleStatamicQueries.php
+++ b/src/Http/Livewire/Traits/HandleStatamicQueries.php
@@ -5,6 +5,7 @@ namespace Reach\StatamicLivewireFilters\Http\Livewire\Traits;
 use Reach\StatamicLivewireFilters\Exceptions\BlueprintNotFoundException;
 use Reach\StatamicLivewireFilters\Exceptions\FieldNotFoundException;
 use Statamic\Facades\Blueprint;
+use Statamic\Facades\Site;
 use Statamic\Facades\Taxonomy;
 
 trait HandleStatamicQueries
@@ -13,7 +14,9 @@ trait HandleStatamicQueries
     {
         $taxonomy = Taxonomy::findByHandle($taxonomy_handle);
 
-        return $taxonomy->queryTerms()->get()->flatMap(function ($term) {
+        $site = Site::current()->handle();
+
+        return $taxonomy->queryTerms()->where('site', $site)->get()->flatMap(function ($term) {
             return [
                 $term->slug() => $term->title(),
             ];

--- a/src/Http/Livewire/Traits/HandleStatamicQueries.php
+++ b/src/Http/Livewire/Traits/HandleStatamicQueries.php
@@ -18,7 +18,7 @@ trait HandleStatamicQueries
 
         return $taxonomy->queryTerms()->where('site', $site)->get()->flatMap(function ($term) {
             return [
-                $term->slug() => $term->title(),
+                $term->inDefaultLocale()->slug() => $term->title(),
             ];
         });
     }

--- a/src/Http/Livewire/Traits/IsSortable.php
+++ b/src/Http/Livewire/Traits/IsSortable.php
@@ -94,16 +94,17 @@ trait IsSortable
     protected function getTaxonomyTermsSortedBy($handle, $sortBy, $sortDirection): void
     {
         $taxonomy = Taxonomy::findByHandle($handle);
-        $site = Site::current()->handle();
 
         // Check if the field exists
         if (! $taxonomy->termBlueprint()->fields()->all()->has($sortBy)) {
             throw new FieldOptionsCannotFindTaxonomyField($sortBy, $handle);
         }
 
+        $site = Site::current()->handle();
+
         $this->statamic_field['options'] = $taxonomy->queryTerms()->where('site', $site)->orderBy($sortBy, $sortDirection)->get()->flatMap(function ($term) {
             return [
-                $term->slug() => $term->title(),
+                $term->inDefaultLocale()->slug() => $term->title(),
             ];
         })->all();
     }

--- a/src/Http/Livewire/Traits/IsSortable.php
+++ b/src/Http/Livewire/Traits/IsSortable.php
@@ -5,6 +5,7 @@ namespace Reach\StatamicLivewireFilters\Http\Livewire\Traits;
 use Livewire\Attributes\Locked;
 use Reach\StatamicLivewireFilters\Exceptions\FieldOptionsCannotFindTaxonomyField;
 use Reach\StatamicLivewireFilters\Exceptions\FieldOptionsCannotSortException;
+use Statamic\Facades\Site;
 use Statamic\Facades\Taxonomy;
 
 trait IsSortable
@@ -93,13 +94,14 @@ trait IsSortable
     protected function getTaxonomyTermsSortedBy($handle, $sortBy, $sortDirection): void
     {
         $taxonomy = Taxonomy::findByHandle($handle);
+        $site = Site::current()->handle();
 
         // Check if the field exists
         if (! $taxonomy->termBlueprint()->fields()->all()->has($sortBy)) {
             throw new FieldOptionsCannotFindTaxonomyField($sortBy, $handle);
         }
 
-        $this->statamic_field['options'] = $taxonomy->queryTerms()->orderBy($sortBy, $sortDirection)->get()->flatMap(function ($term) {
+        $this->statamic_field['options'] = $taxonomy->queryTerms()->where('site', $site)->orderBy($sortBy, $sortDirection)->get()->flatMap(function ($term) {
             return [
                 $term->slug() => $term->title(),
             ];


### PR DESCRIPTION
This pull request includes changes to ensure taxonomy queries are filtered by the current site in the `HandleStatamicQueries` and `IsSortable` traits. The most important changes include adding the `Site` facade and modifying methods to include the site filter in taxonomy queries.