### PR TITLE
Add infinite scroll to LivewireCollection

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,30 @@ Main features:
 - Multiple view options for each component, offering flexibility in presentation.
 - No JavaScript required, except for Flatpickr for the Date filter, simplifying integration.
 
+## Infinite scroll
+
+Paginated collections can switch from numbered pages to a "load more" flow by adding `infinite_scroll="true"` to the tag:
+
+```antlers
+{{ livewire-collection:cars view="cars" paginate="12" infinite_scroll="true" }}
+```
+
+Each `loadMore` call grows the page size by the initial `paginate` value, and the page size resets automatically whenever a filter or sort changes. The bundled view handles this for you. In a custom view, use the `has_more_pages` variable and the `loadMore` action instead of the `{{ links }}` tag:
+
+```antlers
+{{ entries }}
+    <div wire:key="{{ id }}">{{ title }}</div>
+{{ /entries }}
+
+{{ if has_more_pages }}
+    <button wire:click="loadMore" wire:target="loadMore" wire:loading.attr="disabled">
+        Load more
+    </button>
+{{ /if }}
+```
+
+> Note: the loaded-more state lives in the Livewire component, not the URL, so a full page reload resets the list to the first page.
+
 ## License 
 
 When you are ready to deploy to production you need to buy a license at the Statamic Marketplace.

--- a/resources/lang/en/ui.php
+++ b/resources/lang/en/ui.php
@@ -8,6 +8,8 @@ return [
     'clear_all' => 'Clear all',
     'default' => 'Default',
     'entries' => '{0} entries|{1} entry|[2,*] entries',
+    'load_more' => 'Load more',
+    'loading' => 'Loading…',
     'to' => 'to',
     'value' => 'Value',
     'please_select' => 'Please select',

--- a/resources/views/livewire/livewire-collection.antlers.html
+++ b/resources/views/livewire/livewire-collection.antlers.html
@@ -1,13 +1,29 @@
 <div>
-    <div>
+    <div aria-live="polite" wire:loading.attr="aria-busy" wire:target="loadMore">
         {{ entries }}
         <div wire:key="{{ id }}">
             {{ title }}
         </div>
         {{ /entries }}
     </div>
-   
-    <div class="mt-8 flex justify-center">
-        {{ links }}
-    </div>
+
+    {{ if infinite_scroll }}
+        {{ if has_more_pages }}
+        <div class="mt-8 flex justify-center">
+            <button
+                type="button"
+                wire:click="loadMore"
+                wire:target="loadMore"
+                wire:loading.attr="disabled"
+            >
+                <span wire:loading.remove wire:target="loadMore">{{ trans key="statamic-livewire-filters::ui.load_more" }}</span>
+                <span wire:loading wire:target="loadMore" role="status">{{ trans key="statamic-livewire-filters::ui.loading" }}</span>
+            </button>
+        </div>
+        {{ /if }}
+    {{ else }}
+        <div class="mt-8 flex justify-center">
+            {{ links }}
+        </div>
+    {{ /if }}
 </div>

--- a/src/Http/Livewire/LivewireCollection.php
+++ b/src/Http/Livewire/LivewireCollection.php
@@ -39,6 +39,15 @@ class LivewireCollection extends Component
     public $paginate;
 
     #[Locked]
+    public $infiniteScroll = false;
+
+    #[Locked]
+    public $initialPaginate = null;
+
+    #[Locked]
+    public $hasMorePages = false;
+
+    #[Locked]
     public $view = 'livewire-collection';
 
     #[Locked]
@@ -56,6 +65,7 @@ class LivewireCollection extends Component
         } else {
             $this->setParameters(array_merge($params, $this->params));
         }
+        $this->initialPaginate = (int) $this->paginate;
         $this->dispatchParamsUpdated();
 
         $this->runHooks('init');
@@ -171,6 +181,9 @@ class LivewireCollection extends Component
 
     protected function resetPagination()
     {
+        if ($this->infiniteScroll) {
+            $this->paginate = $this->initialPaginate;
+        }
         if ($this->paginate) {
             $this->resetPage();
         }

--- a/src/Http/Livewire/LivewireCollection.php
+++ b/src/Http/Livewire/LivewireCollection.php
@@ -2,6 +2,7 @@
 
 namespace Reach\StatamicLivewireFilters\Http\Livewire;
 
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Livewire\Attributes\Locked;
 use Livewire\Attributes\On;
 use Livewire\Component;
@@ -217,7 +218,7 @@ class LivewireCollection extends Component
         // Update the URL if using custom query string
         $this->updateCustomQueryStringUrl();
 
-        if ($this->paginate) {
+        if ($this->paginate && $entries instanceof LengthAwarePaginator) {
             return $this->withPagination('entries', $entries);
         }
 

--- a/src/Http/Livewire/LivewireCollection.php
+++ b/src/Http/Livewire/LivewireCollection.php
@@ -66,6 +66,15 @@ class LivewireCollection extends Component
             $this->setParameters(array_merge($params, $this->params));
         }
         $this->initialPaginate = (int) $this->paginate;
+
+        if ($this->infiniteScroll && $this->initialPaginate < 1) {
+            $this->infiniteScroll = false;
+        }
+
+        if ($this->infiniteScroll) {
+            $this->resetPage();
+        }
+
         $this->dispatchParamsUpdated();
 
         $this->runHooks('init');
@@ -192,6 +201,12 @@ class LivewireCollection extends Component
     public function clearAll()
     {
         $this->dispatch('clear-all-filters');
+    }
+
+    #[On('clear-all-filters')]
+    public function resetPaginationOnClearAll(): void
+    {
+        $this->resetPagination();
     }
 
     public function entries()

--- a/src/Http/Livewire/LivewireCollection.php
+++ b/src/Http/Livewire/LivewireCollection.php
@@ -72,7 +72,7 @@ class LivewireCollection extends Component
         }
 
         if ($this->infiniteScroll) {
-            $this->resetPage();
+            $this->resetPage($this->paginationPageName());
         }
 
         $this->dispatchParamsUpdated();
@@ -171,12 +171,11 @@ class LivewireCollection extends Component
             ];
         }
 
-        // When using custom query string, disable Livewire's pagination URL handling
-        // to prevent a double pushState (which causes an extra render).
-        // We handle pagination URL ourselves in updateCustomQueryStringUrl().
+        // Suppress Livewire's URL handling for the configured paginator; we manage the
+        // URL ourselves in updateCustomQueryStringUrl().
         if (CustomQueryString::enabled()) {
             return [
-                'paginators.page' => ['except' => '', 'history' => false],
+                'paginators.'.$this->paginationPageName() => ['except' => '', 'history' => false],
             ];
         }
 
@@ -194,7 +193,7 @@ class LivewireCollection extends Component
             $this->paginate = $this->initialPaginate;
         }
         if ($this->paginate) {
-            $this->resetPage();
+            $this->resetPage($this->paginationPageName());
         }
     }
 

--- a/src/Http/Livewire/Traits/GenerateParams.php
+++ b/src/Http/Livewire/Traits/GenerateParams.php
@@ -23,7 +23,9 @@ trait GenerateParams
     protected function removeParamsNotInAllowedFiltersCollection()
     {
         return collect($this->params)->filter(function ($value, $key) {
-            if ($key === 'sort') {
+            // page_name is collection config, not a filter — it must always reach the
+            // Entries tag so Statamic paginates under the same name the addon resets.
+            if ($key === 'sort' || $key === 'page_name') {
                 return true;
             }
             if ($key === 'query_scope') {

--- a/src/Http/Livewire/Traits/HandleParams.php
+++ b/src/Http/Livewire/Traits/HandleParams.php
@@ -98,10 +98,12 @@ trait HandleParams
             $this->paginate = $paramsCollection->pull('paginate');
         }
 
-        // Normalize the legacy `paginate="true" limit="12"` form so growing the page
-        // size never sends both `paginate` and `limit` to the Entries tag (which throws).
-        if ($this->paginate === true && $paramsCollection->has('limit')) {
-            $this->paginate = (int) $paramsCollection->pull('limit');
+        // Resolve the legacy `paginate="true"` form: the page size comes from `limit`.
+        // Without a limit Statamic treats paginate=true as no pagination, so match that
+        // (mirrors allowLegacyStylePaginationLimiting) rather than handing a bare boolean
+        // to the paginator, which would crash withPagination() on a plain collection.
+        if ($this->paginate === true) {
+            $this->paginate = $paramsCollection->has('limit') ? (int) $paramsCollection->pull('limit') : false;
         }
     }
 

--- a/src/Http/Livewire/Traits/HandleParams.php
+++ b/src/Http/Livewire/Traits/HandleParams.php
@@ -21,6 +21,7 @@ trait HandleParams
         $this->extractView($paramsCollection);
         $this->extractLazyPlaceholder($paramsCollection);
         $this->extractPagination($paramsCollection);
+        $this->extractInfiniteScroll($paramsCollection);
         $this->extractAllowedFilters($paramsCollection);
 
         $this->params = $paramsCollection->all();
@@ -95,6 +96,13 @@ trait HandleParams
     {
         if ($paramsCollection->has('paginate')) {
             $this->paginate = $paramsCollection->pull('paginate');
+        }
+    }
+
+    protected function extractInfiniteScroll($paramsCollection)
+    {
+        if ($paramsCollection->has('infinite_scroll')) {
+            $this->infiniteScroll = filter_var($paramsCollection->pull('infinite_scroll'), FILTER_VALIDATE_BOOLEAN);
         }
     }
 

--- a/src/Http/Livewire/Traits/HandleParams.php
+++ b/src/Http/Livewire/Traits/HandleParams.php
@@ -97,6 +97,17 @@ trait HandleParams
         if ($paramsCollection->has('paginate')) {
             $this->paginate = $paramsCollection->pull('paginate');
         }
+
+        // Normalize the legacy `paginate="true" limit="12"` form so growing the page
+        // size never sends both `paginate` and `limit` to the Entries tag (which throws).
+        if ($this->paginate === true && $paramsCollection->has('limit')) {
+            $this->paginate = (int) $paramsCollection->pull('limit');
+        }
+    }
+
+    protected function paginationPageName(): string
+    {
+        return $this->params['page_name'] ?? 'page';
     }
 
     protected function extractInfiniteScroll($paramsCollection)
@@ -309,12 +320,14 @@ trait HandleParams
             parse_str($existingQueryString, $queryParams);
         }
 
-        // Only manage the page query param when this component owns pagination.
+        // Manage the page param under the configured page_name when we own pagination.
         if ($this->paginate && method_exists($this, 'getPage')) {
-            if ($this->getPage() > 1) {
-                $queryParams['page'] = $this->getPage();
+            $pageName = $this->paginationPageName();
+            $currentPage = $this->getPage($pageName);
+            if ($currentPage > 1) {
+                $queryParams[$pageName] = $currentPage;
             } else {
-                unset($queryParams['page']);
+                unset($queryParams[$pageName]);
             }
         }
 

--- a/src/Http/Livewire/Traits/WithPagination.php
+++ b/src/Http/Livewire/Traits/WithPagination.php
@@ -12,6 +12,7 @@ trait WithPagination
             $key => $paginator->items(),
             'links' => $paginator->render(),
             'pagination_total' => $paginator->total(),
+            'infinite_scroll' => $this->infiniteScroll,
         ];
 
         if ($this->infiniteScroll) {
@@ -23,7 +24,7 @@ trait WithPagination
 
     public function loadMore(): void
     {
-        if (! $this->infiniteScroll) {
+        if (! $this->infiniteScroll || ! $this->hasMorePages) {
             return;
         }
 

--- a/src/Http/Livewire/Traits/WithPagination.php
+++ b/src/Http/Livewire/Traits/WithPagination.php
@@ -8,10 +8,25 @@ trait WithPagination
 
     public function withPagination($key, $paginator): array
     {
-        return [
+        $data = [
             $key => $paginator->items(),
             'links' => $paginator->render(),
             'pagination_total' => $paginator->total(),
         ];
+
+        if ($this->infiniteScroll) {
+            $data['has_more_pages'] = $this->hasMorePages = $paginator->hasMorePages();
+        }
+
+        return $data;
+    }
+
+    public function loadMore(): void
+    {
+        if (! $this->infiniteScroll) {
+            return;
+        }
+
+        $this->paginate = (int) $this->paginate + (int) $this->initialPaginate;
     }
 }

--- a/tests/Feature/CustomQueryStringTest.php
+++ b/tests/Feature/CustomQueryStringTest.php
@@ -222,6 +222,45 @@ class CustomQueryStringTest extends TestCase
     }
 
     #[Test]
+    public function it_writes_the_configured_page_name_in_url_when_on_page_greater_than_one()
+    {
+        $params = [
+            'from' => 'pages',
+            'paginate' => 1,
+            'page_name' => 'results',
+            'item_options:is' => 'option1',
+        ];
+
+        // The URL must use the custom page_name, not a dead `page` param.
+        Livewire::test(LivewireCollection::class, ['params' => $params])
+            ->set('paginators.results', 2)
+            ->dispatch('preset-params', ['item_options:is' => 'option1'])
+            ->assertDispatched('update-url', fn ($name, $payload) => str_contains($payload['newUrl'], 'results=2')
+                && ! str_contains($payload['newUrl'], 'page=2'));
+    }
+
+    #[Test]
+    public function it_suppresses_livewire_pagination_url_handling_for_the_configured_page_name()
+    {
+        $params = [
+            'from' => 'pages',
+            'paginate' => 1,
+            'page_name' => 'results',
+        ];
+
+        // queryString() must target the live paginator slot, not paginators.page.
+        $component = Livewire::test(LivewireCollection::class, ['params' => $params])->instance();
+
+        $method = new \ReflectionMethod($component, 'queryString');
+        $method->setAccessible(true);
+        $queryString = $method->invoke($component);
+
+        $this->assertArrayHasKey('paginators.results', $queryString);
+        $this->assertArrayNotHasKey('paginators.page', $queryString);
+        $this->assertFalse($queryString['paginators.results']['history']);
+    }
+
+    #[Test]
     public function it_resolves_current_path_from_non_livewire_requests_without_dropping_query_parameters()
     {
         $request = Request::create('/horizontal?utm_source=google&utm_medium=cpc&utm_campaign=campaign_name&utm_content=content_id', 'GET');

--- a/tests/Feature/LivewireCollectionComponentTest.php
+++ b/tests/Feature/LivewireCollectionComponentTest.php
@@ -614,4 +614,325 @@ class LivewireCollectionComponentTest extends TestCase
             )
             ->assertSet('paginate', 2);
     }
+
+    #[Test]
+    public function infinite_scroll_resets_to_the_initial_page_size_when_sorting()
+    {
+        $params = [
+            'from' => 'clothes',
+            'paginate' => 2,
+            'infinite_scroll' => true,
+        ];
+
+        Livewire::test(LivewireCollectionComponent::class, ['params' => $params])
+            ->call('loadMore')
+            ->assertSet('paginate', 4)
+            ->dispatch('sort-updated', sort: 'title:desc')
+            ->assertSet('paginate', 2);
+    }
+
+    #[Test]
+    public function infinite_scroll_resets_to_the_initial_page_size_when_clearing_a_filter()
+    {
+        EntryFactory::collection('clothes')->slug('red-2')->data(['title' => 'Red 2', 'colors' => ['red']])->create();
+        EntryFactory::collection('clothes')->slug('red-3')->data(['title' => 'Red 3', 'colors' => ['red']])->create();
+        EntryFactory::collection('clothes')->slug('red-4')->data(['title' => 'Red 4', 'colors' => ['red']])->create();
+
+        $params = [
+            'from' => 'clothes',
+            'paginate' => 2,
+            'infinite_scroll' => true,
+        ];
+
+        Livewire::test(LivewireCollectionComponent::class, ['params' => $params])
+            ->dispatch('filter-updated',
+                field: 'colors',
+                condition: 'taxonomy',
+                payload: 'red',
+                modifier: 'any',
+            )
+            ->call('loadMore')
+            ->assertSet('paginate', 4)
+            ->dispatch('clear-filter',
+                field: 'colors',
+                condition: 'taxonomy',
+                modifier: 'any',
+            )
+            ->assertSet('paginate', 2);
+    }
+
+    #[Test]
+    public function infinite_scroll_does_not_grow_the_page_size_past_the_total()
+    {
+        $params = [
+            'from' => 'clothes',
+            'paginate' => 2,
+            'infinite_scroll' => true,
+        ];
+
+        // 3 entries exist. The first loadMore grows 2 -> 4 (covering all 3, no
+        // more pages). A second loadMore must be a no-op since nothing remains.
+        Livewire::test(LivewireCollectionComponent::class, ['params' => $params])
+            ->call('loadMore')
+            ->assertSet('paginate', 4)
+            ->assertSet('hasMorePages', false)
+            ->call('loadMore')
+            ->assertSet('paginate', 4)
+            ->assertSet('hasMorePages', false);
+    }
+
+    #[Test]
+    public function infinite_scroll_keeps_the_total_count_correct_as_the_page_size_grows()
+    {
+        $params = [
+            'from' => 'clothes',
+            'paginate' => 2,
+            'infinite_scroll' => true,
+        ];
+
+        $component = Livewire::test(LivewireCollectionComponent::class, ['params' => $params]);
+
+        $this->assertEquals(3, $component->get('entriesCount'));
+
+        $component->call('loadMore');
+
+        $this->assertEquals(3, $component->get('entriesCount'));
+    }
+
+    #[Test]
+    public function infinite_scroll_is_disabled_when_no_numeric_page_size_is_set()
+    {
+        $params = [
+            'from' => 'clothes',
+            'infinite_scroll' => true,
+        ];
+
+        Livewire::test(LivewireCollectionComponent::class, ['params' => $params])
+            ->assertSet('infiniteScroll', false);
+    }
+
+    #[Test]
+    public function default_view_renders_a_load_more_button_in_infinite_scroll_mode()
+    {
+        $params = [
+            'from' => 'clothes',
+            'paginate' => 2,
+            'infinite_scroll' => true,
+        ];
+
+        $html = Livewire::test(LivewireCollectionComponent::class, ['params' => $params])->html();
+
+        $this->assertStringContainsString('wire:click="loadMore"', $html);
+        $this->assertStringNotContainsString('Pagination Navigation', $html);
+    }
+
+    #[Test]
+    public function default_view_renders_numbered_pagination_when_not_in_infinite_scroll_mode()
+    {
+        $params = [
+            'from' => 'clothes',
+            'paginate' => 2,
+        ];
+
+        $html = Livewire::test(LivewireCollectionComponent::class, ['params' => $params])->html();
+
+        $this->assertStringContainsString('Pagination Navigation', $html);
+        $this->assertStringNotContainsString('wire:click="loadMore"', $html);
+    }
+
+    #[Test]
+    public function infinite_scroll_forces_page_one_on_mount_when_deep_linked_to_a_later_page()
+    {
+        $params = [
+            'from' => 'clothes',
+            'paginate' => 2,
+            'infinite_scroll' => true,
+        ];
+
+        // Landing on ?page=2 must not offset an infinite-scroll list: mount forces
+        // page 1, so the earliest entries stay reachable and there are more to load.
+        Livewire::withQueryParams(['page' => 2])
+            ->test(LivewireCollectionComponent::class, ['params' => $params])
+            ->assertSet('paginators.page', 1)
+            ->assertSet('hasMorePages', true)
+            ->assertSet('entriesCount', 3);
+    }
+
+    #[Test]
+    public function infinite_scroll_never_writes_a_page_param_with_a_custom_query_string()
+    {
+        Config::set('statamic-livewire-filters.custom_query_string', 'filters');
+        Config::set('statamic-livewire-filters.custom_query_string_aliases', [
+            'taxonomy:colors:any' => 'color',
+        ]);
+
+        $params = [
+            'from' => 'clothes',
+            'paginate' => 2,
+            'infinite_scroll' => true,
+        ];
+
+        // Growing the page size keeps the component on page 1, so the custom
+        // query string URL must never gain a ?page= segment.
+        Livewire::test(LivewireCollectionComponent::class, ['params' => $params])
+            ->call('loadMore')
+            ->assertSet('paginate', 4)
+            ->assertSet('paginators.page', 1)
+            ->dispatch('preset-params', [])
+            ->assertDispatched('update-url', fn ($name, $payload) => ! str_contains($payload['newUrl'], 'page='));
+    }
+
+    #[Test]
+    public function infinite_scroll_resets_the_page_size_on_clear_all_even_without_active_filters()
+    {
+        $params = [
+            'from' => 'clothes',
+            'paginate' => 2,
+            'infinite_scroll' => true,
+        ];
+
+        // A grown page size with no active filters must still reset when the
+        // clear-all event fires (the per-filter clear cascade never runs here).
+        Livewire::test(LivewireCollectionComponent::class, ['params' => $params])
+            ->call('loadMore')
+            ->assertSet('paginate', 4)
+            ->dispatch('clear-all-filters')
+            ->assertSet('paginate', 2);
+    }
+
+    #[Test]
+    public function infinite_scroll_can_be_enabled_with_the_string_true_value()
+    {
+        $params = [
+            'from' => 'clothes',
+            'paginate' => 2,
+            'infinite_scroll' => 'true',
+        ];
+
+        Livewire::test(LivewireCollectionComponent::class, ['params' => $params])
+            ->assertSet('infiniteScroll', true);
+    }
+
+    #[Test]
+    public function infinite_scroll_is_disabled_with_the_string_false_value()
+    {
+        $params = [
+            'from' => 'clothes',
+            'paginate' => 2,
+            'infinite_scroll' => 'false',
+        ];
+
+        Livewire::test(LivewireCollectionComponent::class, ['params' => $params])
+            ->assertSet('infiniteScroll', false);
+    }
+
+    #[Test]
+    public function load_more_is_a_no_op_and_view_renders_when_infinite_scroll_is_disabled_at_mount()
+    {
+        $params = [
+            'from' => 'clothes',
+            'infinite_scroll' => true,
+        ];
+
+        $component = Livewire::test(LivewireCollectionComponent::class, ['params' => $params])
+            ->assertSet('infiniteScroll', false)
+            ->call('loadMore')
+            ->assertSet('infiniteScroll', false)
+            ->assertSet('paginate', null);
+
+        // The non-paginated render branch must not error and must not show a button.
+        $this->assertStringNotContainsString('wire:click="loadMore"', $component->html());
+    }
+
+    #[Test]
+    public function infinite_scroll_grows_across_multiple_load_more_calls()
+    {
+        foreach (range(1, 6) as $i) {
+            EntryFactory::collection('clothes')->slug("extra-{$i}")->data(['title' => "Extra {$i}"])->create();
+        }
+
+        $params = [
+            'from' => 'clothes',
+            'paginate' => 2,
+            'infinite_scroll' => true,
+        ];
+
+        // 9 entries, page size 2 -> grows 2,4,6,8,10 across four loadMore calls.
+        Livewire::test(LivewireCollectionComponent::class, ['params' => $params])
+            ->assertSet('hasMorePages', true)
+            ->call('loadMore')->assertSet('paginate', 4)->assertSet('hasMorePages', true)
+            ->call('loadMore')->assertSet('paginate', 6)->assertSet('hasMorePages', true)
+            ->call('loadMore')->assertSet('paginate', 8)->assertSet('hasMorePages', true)
+            ->call('loadMore')->assertSet('paginate', 10)->assertSet('hasMorePages', false)
+            ->call('loadMore')->assertSet('paginate', 10)->assertSet('hasMorePages', false)
+            ->assertSet('paginators.page', 1);
+    }
+
+    #[Test]
+    public function infinite_scroll_keeps_the_count_correct_when_a_filter_is_active()
+    {
+        EntryFactory::collection('clothes')->slug('red-2')->data(['title' => 'Red 2', 'colors' => ['red']])->create();
+        EntryFactory::collection('clothes')->slug('red-3')->data(['title' => 'Red 3', 'colors' => ['red']])->create();
+        EntryFactory::collection('clothes')->slug('red-4')->data(['title' => 'Red 4', 'colors' => ['red']])->create();
+
+        $params = [
+            'from' => 'clothes',
+            'paginate' => 2,
+            'infinite_scroll' => true,
+        ];
+
+        // 6 clothes entries total, 4 of them red. With a red filter applied the
+        // displayed total must be the filtered total (4), not the collection total.
+        $component = Livewire::test(LivewireCollectionComponent::class, ['params' => $params])
+            ->dispatch('filter-updated',
+                field: 'colors',
+                condition: 'taxonomy',
+                payload: 'red',
+                modifier: 'any',
+            );
+
+        $this->assertEquals(4, $component->get('entriesCount'));
+        $component->assertSet('hasMorePages', true);
+
+        $component->call('loadMore')->assertSet('paginate', 4);
+
+        $this->assertEquals(4, $component->get('entriesCount'));
+        $component->assertSet('hasMorePages', false);
+    }
+
+    #[Test]
+    public function has_more_pages_is_not_exposed_when_not_in_infinite_scroll_mode()
+    {
+        $params = [
+            'from' => 'clothes',
+            'paginate' => 2,
+        ];
+
+        $component = Livewire::test(LivewireCollectionComponent::class, ['params' => $params]);
+
+        // The view data carries infinite_scroll => false and omits has_more_pages.
+        $this->assertSame(false, $component->viewData('infinite_scroll'));
+    }
+
+    #[Test]
+    public function default_view_in_infinite_mode_uses_translatable_strings_and_aria_attributes()
+    {
+        $params = [
+            'from' => 'clothes',
+            'paginate' => 2,
+            'infinite_scroll' => true,
+        ];
+
+        $html = Livewire::test(LivewireCollectionComponent::class, ['params' => $params])->html();
+
+        // Translation keys resolve to their values rather than being emitted raw.
+        $this->assertStringContainsString('Load more', $html);
+        $this->assertStringContainsString('Loading', $html);
+        $this->assertStringNotContainsString('statamic-livewire-filters::ui', $html);
+
+        // Accessibility hooks for the dynamically injected entries and loading state.
+        $this->assertStringContainsString('aria-live="polite"', $html);
+        $this->assertStringContainsString('aria-busy', $html);
+        $this->assertStringContainsString('role="status"', $html);
+    }
 }

--- a/tests/Feature/LivewireCollectionComponentTest.php
+++ b/tests/Feature/LivewireCollectionComponentTest.php
@@ -575,4 +575,43 @@ class LivewireCollectionComponentTest extends TestCase
             $this->assertStringContainsString('custom-view', $e->getMessage());
         }
     }
+
+    #[Test]
+    public function infinite_scroll_grows_the_page_size_and_exposes_has_more_pages()
+    {
+        $params = [
+            'from' => 'clothes',
+            'paginate' => 2,
+            'infinite_scroll' => true,
+        ];
+
+        Livewire::test(LivewireCollectionComponent::class, ['params' => $params])
+            ->assertSet('infiniteScroll', true)
+            ->assertSet('initialPaginate', 2)
+            ->assertSet('hasMorePages', true)
+            ->call('loadMore')
+            ->assertSet('paginate', 4)
+            ->assertSet('hasMorePages', false);
+    }
+
+    #[Test]
+    public function infinite_scroll_resets_to_the_initial_page_size_when_filtering()
+    {
+        $params = [
+            'from' => 'clothes',
+            'paginate' => 2,
+            'infinite_scroll' => true,
+        ];
+
+        Livewire::test(LivewireCollectionComponent::class, ['params' => $params])
+            ->call('loadMore')
+            ->assertSet('paginate', 4)
+            ->dispatch('filter-updated',
+                field: 'colors',
+                condition: 'taxonomy',
+                payload: 'red',
+                modifier: 'any',
+            )
+            ->assertSet('paginate', 2);
+    }
 }

--- a/tests/Feature/LivewireCollectionComponentTest.php
+++ b/tests/Feature/LivewireCollectionComponentTest.php
@@ -935,4 +935,43 @@ class LivewireCollectionComponentTest extends TestCase
         $this->assertStringContainsString('aria-busy', $html);
         $this->assertStringContainsString('role="status"', $html);
     }
+
+    #[Test]
+    public function infinite_scroll_supports_the_legacy_boolean_paginate_with_limit()
+    {
+        $params = [
+            'from' => 'clothes',
+            'paginate' => true,
+            'limit' => 2,
+            'infinite_scroll' => true,
+        ];
+
+        // Legacy `paginate="true" limit="2"` must resolve to page size 2 and grow
+        // without throwing on the `paginate`+`limit` collision.
+        Livewire::test(LivewireCollectionComponent::class, ['params' => $params])
+            ->assertSet('initialPaginate', 2)
+            ->assertSet('hasMorePages', true)
+            ->call('loadMore')
+            ->assertSet('paginate', 4)
+            ->assertSet('hasMorePages', false);
+    }
+
+    #[Test]
+    public function infinite_scroll_forces_page_one_on_mount_with_a_custom_page_name()
+    {
+        $params = [
+            'from' => 'clothes',
+            'paginate' => 2,
+            'page_name' => 'results',
+            'infinite_scroll' => true,
+        ];
+
+        // A custom paginator name must also reset to page 1, so ?results=2 doesn't
+        // drop the earliest entries.
+        Livewire::withQueryParams(['results' => 2])
+            ->test(LivewireCollectionComponent::class, ['params' => $params])
+            ->assertSet('paginators.results', 1)
+            ->assertSet('hasMorePages', true)
+            ->assertSet('entriesCount', 3);
+    }
 }

--- a/tests/Feature/LivewireCollectionComponentTest.php
+++ b/tests/Feature/LivewireCollectionComponentTest.php
@@ -974,4 +974,62 @@ class LivewireCollectionComponentTest extends TestCase
             ->assertSet('hasMorePages', true)
             ->assertSet('entriesCount', 3);
     }
+
+    #[Test]
+    public function allowed_filters_keeps_the_custom_page_name_in_the_statamic_query()
+    {
+        $component = Livewire::test(LivewireCollectionComponent::class, ['params' => [
+            'from' => 'clothes',
+            'paginate' => 2,
+            'page_name' => 'results',
+            'allowed_filters' => 'taxonomy:colors:any',
+        ]])->instance();
+
+        // allowed_filters must not strip page_name, otherwise Statamic paginates under
+        // 'page' while the addon resets/writes 'results'.
+        $method = new \ReflectionMethod($component, 'generateParams');
+        $method->setAccessible(true);
+
+        $this->assertSame('results', $method->invoke($component)->get('page_name'));
+    }
+
+    #[Test]
+    public function allowed_filters_resets_the_real_custom_paginator_when_filtering()
+    {
+        $params = [
+            'from' => 'clothes',
+            'paginate' => 2,
+            'page_name' => 'results',
+            'allowed_filters' => 'taxonomy:colors:any',
+        ];
+
+        // Deep-linked to results=2, Statamic must honour the custom paginator (proving
+        // the name survived allowed_filters), and applying a filter must reset it.
+        Livewire::withQueryParams(['results' => 2])
+            ->test(LivewireCollectionComponent::class, ['params' => $params])
+            ->assertSet('paginators.results', 2)
+            ->dispatch('filter-updated',
+                field: 'colors',
+                condition: 'taxonomy',
+                payload: 'red',
+                modifier: 'any',
+            )
+            ->assertSet('paginators.results', 1);
+    }
+
+    #[Test]
+    public function paginate_true_without_a_limit_renders_unpaginated_instead_of_crashing()
+    {
+        $params = [
+            'from' => 'clothes',
+            'paginate' => true,
+        ];
+
+        // Legacy paginate="true" with no limit means "no pagination" to Statamic, which
+        // returns a plain collection — the component must not call paginator methods on it.
+        Livewire::test(LivewireCollectionComponent::class, ['params' => $params])
+            ->assertSet('paginate', false)
+            ->assertSet('entriesCount', 3)
+            ->assertSet('infiniteScroll', false);
+    }
 }


### PR DESCRIPTION
Adds an `infinite_scroll` option to paginated collections, that allows switching from numbered pages to a "load more" flow.

**How it works**
- Set `infinite_scroll="true"` on the tag to enable it.
- Each `loadMore` call grows the page size by the initial `paginate` value.
- Page size resets automatically when a filter or sort changes.

**Usage**
```
{{ livewire-collection:cars view="cars" paginate="12" infinite_scroll="true" }}
```

In the view, use the `has_more_pages` variable and `loadMore` action.
```
{{ entries }}
    <div wire:key="{{ id }}">{{ title }}</div>
{{ /entries }}

{{ if has_more_pages }}
    <button wire:click="loadMore" wire:target="loadMore" wire:loading.attr="disabled">
        Load more
    </button>
{{ /if }}
```